### PR TITLE
Add support page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,6 +31,7 @@
           <nav>
             <a href="{{ site.baseurl }}/">Home</a>
             <a href="{{ site.baseurl }}/devices.html">Devices</a>
+            <a href="{{ site.baseurl }}/support.html">Support</a>
             <a href="{{ site.baseurl }}/contribute.html">Contribute</a>
             <a href="{{ site.baseurl }}/blog.html">Blog</a>
           </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
           </div>
 
           <nav>
-            <a href="{{ site.baseurl }}/">About</a>
+            <a href="{{ site.baseurl }}/">Home</a>
             <a href="{{ site.baseurl }}/devices.html">Devices</a>
             <a href="{{ site.baseurl }}/contribute.html">Contribute</a>
             <a href="{{ site.baseurl }}/blog.html">Blog</a>

--- a/style.scss
+++ b/style.scss
@@ -232,7 +232,7 @@ nav {
   }
 
   a {
-    margin-left: 20px;
+    margin-left: 14px;
     color: $darkGray;
     text-align: right;
     font-weight: 300;

--- a/support.md
+++ b/support.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Support
+---
+
+## Support
+
+### Documentation
+
+### Downloads


### PR DESCRIPTION
Here's a proposal to add a new "Support" section to the navigation bar. We don't have much space here. As you can see, I already had to reduce the margin-left to make it fit. We probably won't be able to add more pages to the navigation from here on.

What do you think about this top-level navigation? Will it fit for all content? I imagine the following:

- Home
- Devices
- Support
  - Documentation
  - Downloads
  - Links to forums etc.
- Contribute
  - Info about Gerrit
  - Bugtracker
  - other ways to contribute
- Blog
